### PR TITLE
fix(transcription): load PCM WAV via stdlib to skip PyAV decode

### DIFF
--- a/core/audio/wav_for_whisper.py
+++ b/core/audio/wav_for_whisper.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import wave
+from pathlib import Path
+
+import numpy as np
+
+
+def _linear_resample_mono(audio: np.ndarray, orig_sr: int, target_sr: int) -> np.ndarray:
+    if orig_sr == target_sr or audio.size == 0:
+        return audio.astype(np.float32, copy=False)
+    duration = audio.shape[0] / orig_sr
+    target_len = max(1, int(round(duration * target_sr)))
+    x_old = np.linspace(0.0, duration, num=audio.shape[0], endpoint=False, dtype=np.float64)
+    x_new = np.linspace(0.0, duration, num=target_len, endpoint=False, dtype=np.float64)
+    return np.interp(x_new, x_old, audio.astype(np.float64)).astype(np.float32)
+
+
+def try_load_wav_for_faster_whisper(
+    path: str | Path,
+    *,
+    target_sr: int,
+) -> np.ndarray | None:
+    """Load 16-bit PCM WAV (mono/stereo) for faster-whisper; float32 mono at target_sr.
+
+    Returns None if the file is not a supported WAV (other formats keep file-path fallback).
+    """
+    path = Path(path)
+    if path.suffix.lower() != ".wav":
+        return None
+
+    try:
+        with wave.open(str(path), "rb") as wf:
+            if wf.getcomptype() != "NONE" or wf.getsampwidth() != 2:
+                return None
+            n_channels = wf.getnchannels()
+            if n_channels not in (1, 2):
+                return None
+            framerate = wf.getframerate()
+            if framerate <= 0:
+                return None
+            raw = wf.readframes(wf.getnframes())
+    except (OSError, EOFError, wave.Error):
+        return None
+
+    if not raw:
+        return np.zeros(0, dtype=np.float32)
+
+    pcm = np.frombuffer(raw, dtype="<i2")
+    if pcm.size % n_channels != 0:
+        return None
+    pcm = pcm.reshape(-1, n_channels)
+    if n_channels == 2:
+        # Match PyAV mono path: mean of channels, same scale as decode_audio (s16 -> f32)
+        audio_f = pcm.astype(np.float32).mean(axis=1) / 32768.0
+    else:
+        audio_f = pcm[:, 0].astype(np.float32) / 32768.0
+
+    return _linear_resample_mono(audio_f, framerate, target_sr)

--- a/core/transcription/service.py
+++ b/core/transcription/service.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 import threading
 from pathlib import Path
 
+import numpy as np
 from faster_whisper import BatchedInferencePipeline
 from PySide6.QtCore import QObject, Signal, QRunnable, QThreadPool
 
+from core.audio.wav_for_whisper import try_load_wav_for_faster_whisper
 from core.temp_file_manager import temp_file_manager
 from core.text.curation import curate_text
 from core.output.writers import SegmentData, TranscriptionResult
@@ -65,6 +67,13 @@ class _TranscriptionRunnable(QRunnable):
 
             logger.info(f"Starting transcription: {self.audio_file}")
 
+            whisper_sr = self.model.feature_extractor.sampling_rate
+            audio_input: str | np.ndarray = try_load_wav_for_faster_whisper(
+                self.audio_file, target_sr=whisper_sr
+            )
+            if audio_input is None:
+                audio_input = str(self.audio_file)
+
             extra_kwargs = {
                 "without_timestamps": self.whisper_params.get("without_timestamps", True),
                 "word_timestamps": self.whisper_params.get("word_timestamps", False),
@@ -76,7 +85,7 @@ class _TranscriptionRunnable(QRunnable):
             if self.batch_size is not None and int(self.batch_size) > 1:
                 batched_model = BatchedInferencePipeline(model=self.model)
                 segments, info = batched_model.transcribe(
-                    str(self.audio_file),
+                    audio_input,
                     language=None,
                     task=self.task_mode,
                     batch_size=int(self.batch_size),
@@ -84,7 +93,7 @@ class _TranscriptionRunnable(QRunnable):
                 )
             else:
                 segments, info = self.model.transcribe(
-                    str(self.audio_file),
+                    audio_input,
                     language=None,
                     task=self.task_mode,
                     **extra_kwargs,


### PR DESCRIPTION
**Problem** *- on Linux (CachyOS)*
Transcription after recording can fail with `UnicodeDecodeError` (e.g. `'ascii' codec can't decode byte …`) in `av.error.err_check` when PyAV decodes FFmpeg error paths as ASCII. This shows up on some locales (e.g. German) when FFmpeg/PyAV surfaces non-ASCII text.

**Cause**  
faster-whisper decodes and resamples via PyAV; FFmpeg error handling can expose non-ASCII strings, and PyAV may decode them incorrectly. In-app recordings are standard PCM WAV.

**Solution**  
For supported `.wav` files (16-bit PCM, mono or stereo), load audio with the stdlib `wave` module and NumPy, optionally downmix stereo to mono, linearly resample to `feature_extractor.sampling_rate (16 kHz)`, and pass a `float32` `np.ndarray` into `transcribe` / `BatchedInferencePipeline.transcribe` so faster-whisper skips `decode_audio`. Unsupported WAV variants and all non-WAV inputs keep the previous behavior (file path string → PyAV pipeline unchanged).

**Testing**  
- Synthetic 44.1 kHz mono int16 WAV through the loader (resampled length ~16k at 16 kHz).  
- Non-`.wav` path still yields `None` → string path unchanged.  

*Prepared with assistance from [Cursor](https://cursor.com/) (AI editor). I have tested the changes locally, please still give the patch a careful review before merging.*