### PR TITLE
Add Parakeet ONNX and speaker labels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,11 @@ logs/
 
 # Runtime/temp
 runtime/
+model_cache/
+pip-cache/
+pip-tmp/
+uv-cache/
+uv-python/
 .lock
 nul
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@
 - Configurable file type filtering
 - Multiple output formats: txt, srt, vtt, tsv, json
 - Output to clipboard, source directory, or custom directory
+- Optional speaker labeling mode for recorded calls and imported audio files
+- Speaker label settings for 2-8 expected speakers
+- Optional voice enrollment for the primary speaker, used only when the match is confident
+- Optional NVIDIA Parakeet TDT 0.6B v3 transcription through ONNX Runtime
 - Real-time system monitoring (CPU, RAM, GPU, VRAM, Power)
 - Global hotkey support
 - Dockable clipboard and file transcription panels
@@ -24,22 +28,51 @@
 
 ## Supported Models
 
-Uses the [faster-whisper](https://github.com/SYSTRAN/faster-whisper) library, which provides CTranslate2-based inference for OpenAI's Whisper models.  Supports both transcription and translation tasks depending on the model selected.
+Uses the [faster-whisper](https://github.com/SYSTRAN/faster-whisper) library, which provides CTranslate2-based inference for OpenAI's Whisper models. Supports both transcription and translation tasks depending on the model selected.
 
-## ⚙️ Windows Installer
+This fork also adds optional local Parakeet support:
+
+- `parakeet-tdt-0.6b-v3-onnx`
+- Runs locally through [onnx-asr](https://pypi.org/project/onnx-asr/) and ONNX Runtime
+- Uses `CUDAExecutionProvider` when ONNX Runtime GPU is available
+- Avoids NVIDIA NeMo as an application dependency
+- Downloads and caches the ONNX model on first use
+
+Parakeet is transcription-only. Whisper models remain available and are still the recommended fallback for compatibility.
+
+## Speaker Labels
+
+The clipboard panel includes a `Speaker Labels` checkbox. When enabled, the app assigns speaker names to both live recordings and imported audio files.
+
+In Settings:
+
+- `Speaker Labels...` lets you set 2-8 expected speaker names, such as Lawyer, Client, Adjuster, or Interpreter.
+- `Voice Enrollment...` records a short sample of the primary speaker. The sample is used only when the match is distinct enough; otherwise the app falls back to normal speaker ordering.
+
+Speaker labeling uses fast local audio features and does not send audio to a cloud service. It is intended as a lightweight helper, not a guaranteed forensic diarization system.
+
+## Windows Installer
+
 > Download and run [```FasterWhisperTranscriber_Setup.exe```](https://github.com/BBC-Esq/Faster-Whisper-Transcriber/releases/latest/download/FasterWhisperTranscriber_Setup.exe).
 
-## 💻 Install And Run from Virtual Environment
+## Install And Run from Virtual Environment
+
 > Download the latest release...unzip and extract...go to the directory containing ```main.py```...run these commands in order:
+
 ```
 python -m venv .
 ```
+
 ```
 .\Scripts\activate
 ```
+
 ```
 python install.py
 ```
+
 ```
 python main.py
 ```
+
+During install, the app can optionally install Parakeet ONNX support. The regular Faster Whisper install is unaffected if the optional Parakeet install is skipped or fails.

--- a/config/manager.py
+++ b/config/manager.py
@@ -22,9 +22,9 @@ class ConfigManager:
         "task_modes": {"transcribe", "translate"},
         "quantization_types": {
             "int8", "int8_float16", "int8_float32", "int8_bfloat16",
-            "int16", "float16", "float32", "bfloat16"
+            "int16", "float16", "float32", "bfloat16", "onnx"
         },
-        "output_formats": {"txt", "srt", "vtt", "json"},
+        "output_formats": {"txt", "srt", "vtt", "tsv", "json"},
         "single_file_output_modes": {
             "clipboard", "save_to_source", "save_and_clipboard", "save_to_custom"
         },
@@ -39,6 +39,10 @@ class ConfigManager:
         "supported_quantizations": {"cpu": [], "cuda": []},
         "curate_transcription": True,
         "clipboard_append_mode": False,
+        "client_call_mode": False,
+        "speaker_labels": ["Lawyer", "Client"],
+        "speaker_voice_profiles": {},
+        "include_timestamps": False,
         "without_timestamps": True,
         "word_timestamps": False,
         "beam_size": 5,
@@ -64,6 +68,10 @@ class ConfigManager:
         "show_clipboard_window": {"type": bool},
         "curate_transcription": {"type": bool},
         "clipboard_append_mode": {"type": bool},
+        "client_call_mode": {"type": bool},
+        "speaker_labels": {"type": list, "validator": "_validate_speaker_labels"},
+        "speaker_voice_profiles": {"type": dict, "validator": "_validate_voice_profiles"},
+        "include_timestamps": {"type": bool},
         "without_timestamps": {"type": bool},
         "word_timestamps": {"type": bool},
         "beam_size": {"type": int, "validator": "_validate_beam_size"},
@@ -151,6 +159,49 @@ class ConfigManager:
         if isinstance(value, int) and 1 <= value <= 20:
             return value
         return self.DEFAULT_CONFIG["beam_size"]
+
+    def _validate_speaker_labels(self, value: Any) -> list[str]:
+        if not isinstance(value, list):
+            return copy.deepcopy(self.DEFAULT_CONFIG["speaker_labels"])
+
+        labels = []
+        for item in value[:8]:
+            label = str(item).strip() if item is not None else ""
+            labels.append(label)
+
+        defaults = self.DEFAULT_CONFIG["speaker_labels"]
+        while len(labels) < 2:
+            labels.append(defaults[len(labels)])
+
+        cleaned = []
+        for idx, label in enumerate(labels):
+            if label:
+                cleaned.append(label)
+            elif idx < len(defaults):
+                cleaned.append(defaults[idx])
+            else:
+                cleaned.append(f"Speaker {idx + 1}")
+        return cleaned
+
+    def _validate_voice_profiles(self, value: Any) -> dict[str, list[float]]:
+        if not isinstance(value, dict):
+            return {}
+
+        cleaned: dict[str, list[float]] = {}
+        for key in ("speaker_1",):
+            raw_profile = value.get(key)
+            if not isinstance(raw_profile, list):
+                continue
+            profile = []
+            for item in raw_profile:
+                try:
+                    profile.append(float(item))
+                except (TypeError, ValueError):
+                    profile = []
+                    break
+            if profile:
+                cleaned[key] = profile
+        return cleaned
 
     def _validate_port(self, value: Any) -> int:
         if isinstance(value, int) and 1024 <= value <= 65535:

--- a/core/controller.py
+++ b/core/controller.py
@@ -70,13 +70,19 @@ class TranscriberController(QObject):
         return version
 
     def _load_whisper_params(self) -> None:
-        include_timestamps = config_manager.get_value("include_timestamps", False)
+        include_timestamps = config_manager.get_value(
+            "include_timestamps",
+            not config_manager.get_value("without_timestamps", True),
+        )
         params = {
             "without_timestamps": not include_timestamps,
             "word_timestamps": False,
             "beam_size": config_manager.get_value("beam_size", 5),
             "vad_filter": config_manager.get_value("vad_filter", False),
             "condition_on_previous_text": config_manager.get_value("condition_on_previous_text", True),
+            "client_call_mode": config_manager.get_value("client_call_mode", False),
+            "speaker_labels": config_manager.get_value("speaker_labels", ["Lawyer", "Client"]),
+            "speaker_voice_profiles": config_manager.get_value("speaker_voice_profiles", {}),
         }
         self.transcription_service.set_whisper_params(params)
 

--- a/core/models/loader.py
+++ b/core/models/loader.py
@@ -5,8 +5,10 @@ import shutil
 import sys
 import threading
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Optional, Callable
 
+import numpy as np
 import psutil
 from faster_whisper import WhisperModel
 from huggingface_hub import HfApi, hf_hub_download, snapshot_download
@@ -16,6 +18,13 @@ from core.logging_config import get_logger
 from core.exceptions import ModelLoadError
 
 logger = get_logger(__name__)
+
+PARAKEET_ONNX_MODEL_NAME = "parakeet-tdt-0.6b-v3-onnx"
+PARAKEET_ONNX_ASR_NAME = "nemo-parakeet-tdt-0.6b-v3"
+
+
+def is_parakeet_onnx_model(model_name: str) -> bool:
+    return model_name == PARAKEET_ONNX_MODEL_NAME
 
 
 class _NullWriter:
@@ -73,6 +82,234 @@ def _make_repo_string(model_name: str, quantization_type: str) -> str:
     if model_name.startswith("distil-whisper"):
         return f"ctranslate2-4you/{model_name}-ct2-{quantization_type}"
     return f"ctranslate2-4you/whisper-{model_name}-ct2-{quantization_type}"
+
+
+class ParakeetOnnxModel:
+    expects_file_path = True
+
+    def __init__(self, text_model, segment_model=None, providers: list[str] | None = None) -> None:
+        self._text_model = text_model
+        self._timestamp_model = text_model.with_timestamps()
+        self._segment_model = segment_model
+        self.provider_names = list(providers or [])
+        self.engine_name = "Parakeet ONNX"
+        self.sample_rate = 16000
+
+    def transcribe(
+        self,
+        audio_input,
+        language=None,
+        task: str = "transcribe",
+        **_kwargs,
+    ):
+        if task == "translate":
+            raise ModelLoadError("Parakeet ONNX supports transcription only")
+
+        audio = self._load_audio(audio_input)
+        duration = float(audio.shape[0] / self.sample_rate) if audio.size else 0.0
+
+        if self._segment_model is not None:
+            try:
+                segments = self._recognize_vad_segments(audio)
+            except Exception as exc:
+                logger.warning(f"Parakeet VAD segmentation failed, using timestamps: {exc}")
+                segments = self._recognize_timestamp_segments(audio, duration)
+        else:
+            segments = self._recognize_timestamp_segments(audio, duration)
+
+        info = SimpleNamespace(duration=duration, language=None)
+        return iter(segments), info
+
+    def _load_audio(self, audio_input) -> np.ndarray:
+        if isinstance(audio_input, np.ndarray):
+            audio = np.asarray(audio_input, dtype=np.float32)
+            if audio.ndim == 2:
+                audio = audio.mean(axis=1)
+            return audio.reshape(-1).astype(np.float32, copy=False)
+
+        from faster_whisper.audio import decode_audio
+
+        audio = decode_audio(str(audio_input), sampling_rate=self.sample_rate)
+        audio = np.asarray(audio, dtype=np.float32)
+        if audio.ndim == 2:
+            audio = audio.mean(axis=1)
+        return audio.reshape(-1).astype(np.float32, copy=False)
+
+    def _recognize_vad_segments(self, audio: np.ndarray) -> list[SimpleNamespace]:
+        results = list(
+            self._segment_model.recognize(
+                audio,
+                sample_rate=self.sample_rate,
+                channel="mean",
+            )
+        )
+        segments = [
+            SimpleNamespace(
+                start=float(result.start),
+                end=float(result.end),
+                text=str(result.text).strip(),
+            )
+            for result in results
+            if str(result.text).strip()
+        ]
+        if not segments:
+            return self._recognize_timestamp_segments(
+                audio, float(audio.shape[0] / self.sample_rate)
+            )
+        return segments
+
+    def _recognize_timestamp_segments(
+        self,
+        audio: np.ndarray,
+        duration: float,
+    ) -> list[SimpleNamespace]:
+        result = self._timestamp_model.recognize(
+            audio,
+            sample_rate=self.sample_rate,
+            channel="mean",
+        )
+        text = str(getattr(result, "text", "")).strip()
+        tokens = getattr(result, "tokens", None) or []
+        timestamps = getattr(result, "timestamps", None) or []
+
+        if not text:
+            return []
+        if not tokens or not timestamps or len(tokens) != len(timestamps):
+            return [SimpleNamespace(start=0.0, end=duration, text=text)]
+
+        segments: list[SimpleNamespace] = []
+        start = float(timestamps[0])
+        last_time = start
+        parts: list[str] = []
+
+        for token, ts in zip(tokens, timestamps):
+            token_text = str(token)
+            current_time = float(ts)
+            parts.append(token_text)
+            last_time = current_time
+            if token_text.strip().endswith((".", "?", "!")) or current_time - start >= 12.0:
+                chunk = "".join(parts).strip()
+                if chunk:
+                    segments.append(
+                        SimpleNamespace(
+                            start=max(0.0, start),
+                            end=min(duration, max(current_time, start + 0.25)),
+                            text=chunk,
+                        )
+                    )
+                parts = []
+                start = current_time
+
+        chunk = "".join(parts).strip()
+        if chunk:
+            segments.append(
+                SimpleNamespace(
+                    start=max(0.0, start),
+                    end=min(duration, max(last_time, start + 0.25)),
+                    text=chunk,
+                )
+            )
+
+        return segments or [SimpleNamespace(start=0.0, end=duration, text=text)]
+
+
+def _onnx_cache_root() -> Path:
+    return Path(__file__).resolve().parents[2] / "model_cache" / "onnx"
+
+
+def _configure_onnx_hf_cache(cache_root: Path) -> None:
+    hf_home = cache_root / "hf_home"
+    os.environ["HF_HOME"] = str(hf_home)
+    os.environ["HF_HUB_CACHE"] = str(hf_home / "hub")
+    os.environ["HF_XET_CACHE"] = str(hf_home / "xet")
+    os.environ.setdefault("HF_HUB_DISABLE_SYMLINKS_WARNING", "1")
+    hf_home.mkdir(parents=True, exist_ok=True)
+
+
+def _clear_incomplete_onnx_cache(path: Path, required_files: tuple[str, ...]) -> None:
+    if not path.exists():
+        return
+    if all((path / filename).is_file() for filename in required_files):
+        return
+    logger.warning(f"Clearing incomplete ONNX model cache: {path}")
+    shutil.rmtree(path, onerror=_on_rmtree_error)
+    if path.exists():
+        _force_remove_tree(path)
+
+
+def _onnx_providers(device_type: str) -> list[str]:
+    try:
+        import onnxruntime as ort
+
+        available = set(ort.get_available_providers())
+    except Exception:
+        available = set()
+
+    if device_type == "cuda" and "CUDAExecutionProvider" in available:
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    if device_type == "cuda":
+        logger.warning("ONNX Runtime CUDA provider unavailable; using CPU provider")
+    return ["CPUExecutionProvider"]
+
+
+def _onnx_session_options():
+    import onnxruntime as ort
+
+    sess_options = ort.SessionOptions()
+    sess_options.log_severity_level = 3
+    return sess_options
+
+
+def load_parakeet_onnx_model(device_type: str = "cpu") -> ParakeetOnnxModel:
+    try:
+        import onnx_asr
+    except Exception as exc:
+        raise ModelLoadError(
+            "Parakeet ONNX requires onnx-asr and onnxruntime-gpu. "
+            "Run the installer with Parakeet ONNX support enabled."
+        ) from exc
+
+    providers = _onnx_providers(device_type)
+    cache_root = _onnx_cache_root()
+    cache_root.mkdir(parents=True, exist_ok=True)
+    _configure_onnx_hf_cache(cache_root)
+    model_dir = cache_root / "parakeet-tdt-0.6b-v3"
+    vad_dir = cache_root / "silero-vad"
+    _clear_incomplete_onnx_cache(
+        model_dir,
+        ("config.json", "encoder-model.onnx", "decoder_joint-model.onnx", "vocab.txt"),
+    )
+    _clear_incomplete_onnx_cache(vad_dir, ("silero_vad.onnx",))
+
+    try:
+        logger.info(f"Loading Parakeet ONNX with providers: {providers}")
+        text_model = onnx_asr.load_model(
+            PARAKEET_ONNX_ASR_NAME,
+            path=model_dir,
+            sess_options=_onnx_session_options(),
+            providers=providers,
+        )
+    except Exception as exc:
+        raise ModelLoadError(f"Error loading Parakeet ONNX model: {exc}") from exc
+
+    segment_model = None
+    try:
+        vad = onnx_asr.load_vad(
+            "silero",
+            path=vad_dir,
+            sess_options=_onnx_session_options(),
+            providers=["CPUExecutionProvider"],
+        )
+        segment_model = text_model.with_vad(
+            vad,
+            max_speech_duration_s=25,
+            min_silence_duration_ms=350,
+            speech_pad_ms=80,
+        )
+    except Exception as exc:
+        logger.warning(f"Parakeet ONNX VAD unavailable; using token timestamps: {exc}")
+
+    return ParakeetOnnxModel(text_model, segment_model, providers)
 
 
 def _get_local_model_dir(repo_id: str) -> Path:

--- a/core/models/manager.py
+++ b/core/models/manager.py
@@ -14,6 +14,8 @@ from core.models.loader import (
     get_missing_files,
     download_model_files,
     load_model,
+    load_parakeet_onnx_model,
+    is_parakeet_onnx_model,
     validate_model_path,
 )
 from core.logging_config import get_logger
@@ -78,6 +80,22 @@ class _ModelLoaderRunnable(QRunnable):
 
     def run(self) -> None:
         try:
+            if is_parakeet_onnx_model(self.model_name):
+                if self.cancel_event.is_set():
+                    self.signals.download_cancelled.emit(self.model_version)
+                    return
+
+                self.signals.loading_started.emit(self.model_name, self.model_version)
+                model = load_parakeet_onnx_model(self.device)
+                self.signals.model_loaded.emit(
+                    model,
+                    self.model_name,
+                    self.quant_type,
+                    self.device,
+                    self.model_version,
+                )
+                return
+
             repo_id = _make_repo_string(self.model_name, self.quant_type)
 
             if self.cancel_event.is_set():

--- a/core/models/metadata.py
+++ b/core/models/metadata.py
@@ -21,6 +21,7 @@ class ModelMetadata:
         ModelInfo("medium.en", False),
         ModelInfo("large-v3", True),
         ModelInfo("large-v3-turbo", False, {"cpu": ["float32"], "cuda": ["float16", "bfloat16", "float32"]}),
+        ModelInfo("parakeet-tdt-0.6b-v3-onnx", False, {"cpu": ["onnx"], "cuda": ["onnx"]}),
         ModelInfo("distil-whisper-small.en", False, {"cpu": ["float32"], "cuda": ["float16", "bfloat16", "float32"]}),
         ModelInfo("distil-whisper-medium.en", False, {"cpu": ["float32"], "cuda": ["float16", "bfloat16", "float32"]}),
         ModelInfo("distil-whisper-large-v3", False, {"cpu": ["float32"], "cuda": ["float16", "bfloat16", "float32"]}),
@@ -48,7 +49,7 @@ class ModelMetadata:
 
         if info and info.quantization_overrides:
             options = info.quantization_overrides.get(device, [])
-            options = [opt for opt in options if opt in hw_supported]
+            options = [opt for opt in options if opt == "onnx" or opt in hw_supported]
         else:
             options = supported_quantizations.get(device, [])
 

--- a/core/output/writers.py
+++ b/core/output/writers.py
@@ -14,6 +14,7 @@ class SegmentData:
     start: float
     end: float
     text: str
+    speaker: str | None = None
 
 
 @dataclass
@@ -33,10 +34,21 @@ def format_timestamp(seconds: float, delimiter: str = ",") -> str:
     return f"{hours:02d}:{minutes:02d}:{secs:02d}{delimiter}{millis:03d}"
 
 
-def write_txt(segments: list[SegmentData], output_file: Path) -> None:
+def _segment_text(segment: SegmentData) -> str:
+    text = segment.text.strip()
+    if segment.speaker:
+        return f"{segment.speaker}: {text}"
+    return text
+
+
+def write_txt(result: TranscriptionResult, output_file: Path) -> None:
     with open(output_file, "w", encoding="utf-8") as f:
-        for segment in segments:
-            f.write(segment.text.strip() + "\n")
+        text = result.text.strip()
+        if text:
+            f.write(text + "\n")
+        else:
+            for segment in result.segments:
+                f.write(_segment_text(segment) + "\n")
 
 
 def write_srt(segments: list[SegmentData], output_file: Path) -> None:
@@ -47,7 +59,7 @@ def write_srt(segments: list[SegmentData], output_file: Path) -> None:
                 f"{format_timestamp(segment.start, ',')} --> "
                 f"{format_timestamp(segment.end, ',')}\n"
             )
-            f.write(f"{segment.text.strip()}\n\n")
+            f.write(f"{_segment_text(segment)}\n\n")
 
 
 def write_vtt(segments: list[SegmentData], output_file: Path) -> None:
@@ -58,7 +70,17 @@ def write_vtt(segments: list[SegmentData], output_file: Path) -> None:
                 f"{format_timestamp(segment.start, '.')} --> "
                 f"{format_timestamp(segment.end, '.')}\n"
             )
-            f.write(f"{segment.text.strip()}\n\n")
+            f.write(f"{_segment_text(segment)}\n\n")
+
+
+def write_tsv(segments: list[SegmentData], output_file: Path) -> None:
+    with open(output_file, "w", encoding="utf-8") as f:
+        f.write("start\tend\tspeaker\ttext\n")
+        for segment in segments:
+            f.write(
+                f"{segment.start:.3f}\t{segment.end:.3f}\t"
+                f"{segment.speaker or ''}\t{segment.text.strip()}\n"
+            )
 
 
 def write_json(result: TranscriptionResult, output_file: Path) -> None:
@@ -69,6 +91,7 @@ def write_json(result: TranscriptionResult, output_file: Path) -> None:
             {
                 "start": seg.start,
                 "end": seg.end,
+                "speaker": seg.speaker,
                 "text": seg.text.strip(),
             }
             for seg in result.segments
@@ -82,9 +105,10 @@ def write_output(
     result: TranscriptionResult, output_file: Path, fmt: str
 ) -> None:
     writers = {
-        "txt": lambda: write_txt(result.segments, output_file),
+        "txt": lambda: write_txt(result, output_file),
         "srt": lambda: write_srt(result.segments, output_file),
         "vtt": lambda: write_vtt(result.segments, output_file),
+        "tsv": lambda: write_tsv(result.segments, output_file),
         "json": lambda: write_json(result, output_file),
     }
     writer = writers.get(fmt)

--- a/core/server/api_server.py
+++ b/core/server/api_server.py
@@ -201,7 +201,9 @@ def _do_transcription(item: WorkItem) -> Dict[str, Any]:
 
     language = item.settings.language or None
 
-    if item.settings.batch_size and item.settings.batch_size > 1:
+    use_batched_pipeline = not getattr(model, "expects_file_path", False)
+
+    if item.settings.batch_size and item.settings.batch_size > 1 and use_batched_pipeline:
         extra_kwargs["vad_filter"] = True
         extra_kwargs["vad_parameters"] = dict(
             threshold=0.0008,

--- a/core/transcription/batch_processor.py
+++ b/core/transcription/batch_processor.py
@@ -7,6 +7,10 @@ from faster_whisper import BatchedInferencePipeline
 from PySide6.QtCore import QThread, Signal, QElapsedTimer
 
 from core.output.writers import SegmentData, TranscriptionResult, write_output
+from core.transcription.client_call import (
+    apply_client_call_speakers,
+    format_client_call_transcript,
+)
 from core.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -73,16 +77,36 @@ class BatchProcessor(QThread):
         seen_names: dict[str, int] = {}
 
         try:
-            batched_model = BatchedInferencePipeline(model=self.model)
+            use_batched_pipeline = not getattr(self.model, "expects_file_path", False)
+            logger.info(
+                "Batch transcription engine: "
+                f"{getattr(self.model, 'engine_name', type(self.model).__name__)}"
+            )
+            batched_model = (
+                BatchedInferencePipeline(model=self.model)
+                if use_batched_pipeline
+                else self.model
+            )
             total_files = len(self.files)
 
+            client_call_mode = self.whisper_params.get("client_call_mode", False)
             extra_kwargs = {
-                "without_timestamps": self.whisper_params.get("without_timestamps", True),
+                "without_timestamps": False if client_call_mode else self.whisper_params.get("without_timestamps", True),
                 "word_timestamps": self.whisper_params.get("word_timestamps", False),
                 "beam_size": self.whisper_params.get("beam_size", 5),
                 "vad_filter": self.whisper_params.get("vad_filter", True),
                 "condition_on_previous_text": self.whisper_params.get("condition_on_previous_text", False),
             }
+            if use_batched_pipeline and self.batch_size and int(self.batch_size) > 1:
+                extra_kwargs["vad_filter"] = True
+                extra_kwargs["vad_parameters"] = dict(
+                    threshold=0.0008,
+                    neg_threshold=0.0001,
+                    min_speech_duration_ms=500,
+                    max_speech_duration_s=30,
+                    min_silence_duration_ms=1000,
+                    speech_pad_ms=500,
+                )
 
             for idx, audio_file in enumerate(self.files, 1):
                 if self.stop_requested.is_set():
@@ -91,13 +115,21 @@ class BatchProcessor(QThread):
                 self.progress.emit(idx, total_files, f"Processing {audio_file.name}")
 
                 try:
-                    segments, info = batched_model.transcribe(
-                        str(audio_file),
-                        language=None,
-                        task=self.task_mode,
-                        batch_size=self.batch_size,
-                        **extra_kwargs,
-                    )
+                    if use_batched_pipeline:
+                        segments, info = batched_model.transcribe(
+                            str(audio_file),
+                            language=None,
+                            task=self.task_mode,
+                            batch_size=self.batch_size,
+                            **extra_kwargs,
+                        )
+                    else:
+                        segments, info = batched_model.transcribe(
+                            str(audio_file),
+                            language=None,
+                            task=self.task_mode,
+                            **extra_kwargs,
+                        )
 
                     segment_list = []
                     text_parts = []
@@ -116,8 +148,25 @@ class BatchProcessor(QThread):
                     if self.stop_requested.is_set():
                         break
 
+                    if client_call_mode:
+                        try:
+                            if apply_client_call_speakers(
+                                audio_file,
+                                segment_list,
+                                labels=self.whisper_params.get("speaker_labels"),
+                                voice_profiles=self.whisper_params.get("speaker_voice_profiles"),
+                            ):
+                                text = format_client_call_transcript(segment_list)
+                            else:
+                                text = "\n".join(text_parts)
+                        except Exception as e:
+                            logger.warning(f"Client call speaker labeling failed: {e}")
+                            text = "\n".join(text_parts)
+                    else:
+                        text = "\n".join(text_parts)
+
                     result = TranscriptionResult(
-                        text="\n".join(text_parts),
+                        text=text,
                         segments=segment_list,
                         language=info.language if info and hasattr(info, "language") else None,
                         duration=info.duration if info and hasattr(info, "duration") else None,

--- a/core/transcription/client_call.py
+++ b/core/transcription/client_call.py
@@ -1,0 +1,557 @@
+from __future__ import annotations
+
+import wave
+from pathlib import Path
+
+import numpy as np
+
+from core.logging_config import get_logger
+from core.output.writers import SegmentData
+
+logger = get_logger(__name__)
+
+DEFAULT_SPEAKER_LABELS = ("Lawyer", "Client")
+USER_PROFILE_KEY = "speaker_1"
+_EPS = 1e-8
+_PROFILE_MAX_DISTANCE = 0.35
+_PROFILE_MIN_MARGIN = 0.10
+_PROFILE_STRONG_DISTANCE = 0.12
+_PROFILE_STRONG_MARGIN = 0.04
+_PROFILE_STRONG_RATIO = 0.55
+
+
+def apply_client_call_speakers(
+    audio_file: str | Path,
+    segments: list[SegmentData],
+    labels: list[str] | tuple[str, ...] | None = None,
+    voice_profiles: dict[str, list[float]] | None = None,
+) -> bool:
+    """Assign lightweight speaker labels to transcript segments.
+
+    It first tries very fast stereo channel separation, then falls back to
+    simple acoustic clustering for mono or mixed-channel recordings.
+    """
+    if not segments:
+        return False
+
+    labels = _normalize_labels(labels)
+    profiles = _normalize_voice_profiles(voice_profiles)
+
+    loaded = _load_pcm_wav(audio_file)
+    if loaded is None:
+        logger.info("Client call speaker labels skipped: audio could not be decoded")
+        return False
+
+    audio, sample_rate = loaded
+    assigned = _assign_from_stereo_channels(audio, sample_rate, segments, labels, profiles)
+    if assigned is None:
+        assigned = _assign_from_mono_features(audio, sample_rate, segments, labels, profiles)
+
+    if not assigned:
+        return False
+
+    for segment, speaker in zip(segments, assigned):
+        segment.speaker = speaker
+
+    return True
+
+
+def build_voice_profile_from_samples(samples: np.ndarray, sample_rate: int) -> list[float]:
+    samples = np.asarray(samples, dtype=np.float32)
+    if samples.ndim == 2:
+        samples = samples.mean(axis=1)
+
+    feature = _segment_feature(samples, sample_rate, min_seconds=1.0)
+    if feature is None:
+        raise ValueError("Not enough clear speech was captured for a voice profile")
+    return [round(float(value), 6) for value in feature.tolist()]
+
+
+def format_client_call_transcript(segments: list[SegmentData]) -> str:
+    blocks: list[str] = []
+    current_speaker: str | None = None
+    current_parts: list[str] = []
+
+    def flush() -> None:
+        if not current_parts:
+            return
+        speaker = current_speaker or "Speaker"
+        text = " ".join(part.strip() for part in current_parts if part.strip()).strip()
+        if text:
+            blocks.append(f"{speaker}: {text}")
+
+    for segment in segments:
+        text = segment.text.strip()
+        if not text:
+            continue
+        speaker = segment.speaker
+        if speaker != current_speaker:
+            flush()
+            current_speaker = speaker
+            current_parts = [text]
+        else:
+            current_parts.append(text)
+
+    flush()
+    return "\n\n".join(blocks)
+
+
+def _load_pcm_wav(path: str | Path) -> tuple[np.ndarray, int] | None:
+    path = Path(path)
+    if path.suffix.lower() != ".wav":
+        return _load_with_audio_decoder(path)
+
+    try:
+        with wave.open(str(path), "rb") as wf:
+            if wf.getcomptype() != "NONE" or wf.getsampwidth() != 2:
+                return _load_with_audio_decoder(path)
+            channels = wf.getnchannels()
+            if channels not in (1, 2):
+                return _load_with_audio_decoder(path)
+            sample_rate = wf.getframerate()
+            if sample_rate <= 0:
+                return _load_with_audio_decoder(path)
+            raw = wf.readframes(wf.getnframes())
+    except (OSError, EOFError, wave.Error) as exc:
+        logger.debug(f"Unable to read WAV for client call labels: {exc}")
+        return _load_with_audio_decoder(path)
+
+    if not raw:
+        return np.zeros((0, channels), dtype=np.float32), sample_rate
+
+    pcm = np.frombuffer(raw, dtype="<i2")
+    if pcm.size % channels != 0:
+        return _load_with_audio_decoder(path)
+    audio = pcm.reshape(-1, channels).astype(np.float32) / 32768.0
+    return audio, sample_rate
+
+
+def _load_with_audio_decoder(path: Path) -> tuple[np.ndarray, int] | None:
+    try:
+        from faster_whisper.audio import decode_audio
+
+        sample_rate = 16000
+        decoded = decode_audio(str(path), sampling_rate=sample_rate, split_stereo=True)
+        if isinstance(decoded, tuple) and len(decoded) == 2:
+            left, right = decoded
+            size = min(left.size, right.size)
+            if size <= 0:
+                return np.zeros((0, 2), dtype=np.float32), sample_rate
+            audio = np.column_stack([left[:size], right[:size]]).astype(np.float32)
+            return audio, sample_rate
+
+        mono = np.asarray(decoded, dtype=np.float32).reshape(-1, 1)
+        return mono, sample_rate
+    except Exception as exc:
+        logger.debug(f"Unable to decode audio for speaker labels: {exc}")
+        return None
+
+
+def _assign_from_stereo_channels(
+    audio: np.ndarray,
+    sample_rate: int,
+    segments: list[SegmentData],
+    labels: list[str],
+    voice_profiles: dict[str, np.ndarray],
+) -> list[str] | None:
+    if audio.ndim != 2 or audio.shape[1] < 2:
+        return None
+    if len(labels) != 2:
+        return None
+
+    dominant_channels: list[int | None] = []
+    channel_features: dict[int, list[np.ndarray]] = {0: [], 1: []}
+    confident = 0
+    for segment in segments:
+        chunk = _segment_audio(audio, sample_rate, segment)
+        if chunk.size == 0:
+            dominant_channels.append(None)
+            continue
+
+        left = _rms(chunk[:, 0])
+        right = _rms(chunk[:, 1])
+        louder = max(left, right)
+        quieter = max(min(left, right), _EPS)
+        if louder < 0.002 or louder / quieter < 1.35:
+            dominant_channels.append(None)
+            continue
+
+        dominant_channel = 0 if left > right else 1
+        dominant_channels.append(dominant_channel)
+        confident += 1
+        feature = _segment_feature(chunk[:, dominant_channel], sample_rate)
+        if feature is not None:
+            channel_features[dominant_channel].append(feature)
+
+    if confident < max(2, len(segments) // 3):
+        return None
+
+    channel_profiles = {
+        channel: np.median(np.vstack(features), axis=0)
+        for channel, features in channel_features.items()
+        if features
+    }
+    if channel_profiles:
+        feature_size = next(iter(channel_profiles.values())).size
+        voice_profiles = _matching_voice_profiles(voice_profiles, feature_size)
+    channel_to_label = _map_feature_groups_to_labels(channel_profiles, labels, voice_profiles)
+    if not channel_to_label:
+        first_channel = next((ch for ch in dominant_channels if ch is not None), 0)
+        channel_to_label = {
+            first_channel: labels[0],
+            1 - first_channel: labels[1],
+        }
+
+    assigned: list[str] = []
+    previous = labels[0]
+    for channel in dominant_channels:
+        if channel is None:
+            assigned.append(previous)
+            continue
+        previous = channel_to_label[channel]
+        assigned.append(previous)
+
+    logger.info("Client call speaker labels assigned from stereo channel energy")
+    return assigned
+
+
+def _assign_from_mono_features(
+    audio: np.ndarray,
+    sample_rate: int,
+    segments: list[SegmentData],
+    labels: list[str],
+    voice_profiles: dict[str, np.ndarray],
+) -> list[str]:
+    mono = audio.mean(axis=1) if audio.ndim == 2 else audio
+
+    indexed_features: list[tuple[int, np.ndarray]] = []
+    for idx, segment in enumerate(segments):
+        chunk = _segment_audio(mono, sample_rate, segment)
+        feature = _segment_feature(chunk, sample_rate)
+        if feature is not None:
+            indexed_features.append((idx, feature))
+
+    if len(indexed_features) < 2:
+        return [labels[0] for _ in segments]
+
+    feature_matrix = np.vstack([feature for _, feature in indexed_features])
+    speaker_count = max(2, min(len(labels), len(indexed_features)))
+    voice_profiles = _matching_voice_profiles(voice_profiles, feature_matrix.shape[1])
+    cluster_ids = _kmeans(feature_matrix, speaker_count)
+    cluster_profiles = {
+        cluster_id: np.median(feature_matrix[cluster_ids == cluster_id], axis=0)
+        for cluster_id in range(speaker_count)
+        if np.any(cluster_ids == cluster_id)
+    }
+    cluster_order = _ordered_clusters_by_first_appearance(indexed_features, cluster_ids)
+    cluster_to_label = _map_feature_groups_to_labels(
+        cluster_profiles, labels, voice_profiles, cluster_order
+    )
+    if not cluster_to_label:
+        cluster_to_label = _cluster_labels_by_first_appearance(
+            indexed_features, cluster_ids, labels
+        )
+
+    assigned: list[str | None] = [None] * len(segments)
+    for (idx, _), cluster_id in zip(indexed_features, cluster_ids):
+        assigned[idx] = cluster_to_label[int(cluster_id)]
+
+    logger.info("Client call speaker labels assigned from acoustic clustering")
+    return _fill_missing_labels(assigned, labels[0])
+
+
+def _segment_audio(
+    audio: np.ndarray,
+    sample_rate: int,
+    segment: SegmentData,
+) -> np.ndarray:
+    start = max(0, int(segment.start * sample_rate))
+    end = min(audio.shape[0], int(segment.end * sample_rate))
+    if end <= start:
+        return audio[:0]
+    return audio[start:end]
+
+
+def _segment_feature(
+    chunk: np.ndarray,
+    sample_rate: int,
+    min_seconds: float = 0.35,
+) -> np.ndarray | None:
+    if chunk.ndim == 2:
+        chunk = chunk.mean(axis=1)
+    if chunk.size < int(sample_rate * min_seconds):
+        return None
+
+    frame_len = max(512, int(sample_rate * 0.05))
+    hop = max(160, frame_len // 2)
+    if chunk.size < frame_len:
+        return None
+
+    window = np.hanning(frame_len).astype(np.float32)
+    frames = []
+    for start in range(0, chunk.size - frame_len + 1, hop):
+        frame = chunk[start:start + frame_len].astype(np.float32, copy=False)
+        energy = _rms(frame)
+        if energy > 0.003:
+            frames.append(frame)
+
+    if not frames:
+        return None
+
+    freqs = np.fft.rfftfreq(frame_len, d=1.0 / sample_rate)
+    nyquist = max(freqs[-1], 1.0)
+    band_edges = np.array(
+        [80, 150, 250, 400, 650, 1000, 1600, 2600, 4000, 6000, min(8000, nyquist)],
+        dtype=np.float32,
+    )
+    band_edges = band_edges[band_edges <= nyquist]
+    if band_edges.size < 4:
+        band_edges = np.linspace(80, nyquist, 6, dtype=np.float32)
+
+    feature_rows = []
+    for frame in frames:
+        spectrum = np.abs(np.fft.rfft(frame * window)) ** 2
+        total = float(np.sum(spectrum)) + _EPS
+        centroid = float(np.sum(freqs * spectrum) / total) / nyquist
+        bandwidth = float(
+            np.sqrt(np.sum(((freqs / nyquist - centroid) ** 2) * spectrum) / total)
+        )
+        zcr = float(np.mean(np.abs(np.diff(np.signbit(frame)))))
+        rms = _rms(frame)
+
+        band_values = []
+        for low, high in zip(band_edges[:-1], band_edges[1:]):
+            mask = (freqs >= low) & (freqs < high)
+            band_energy = float(np.sum(spectrum[mask])) / total if np.any(mask) else 0.0
+            band_values.append(np.log1p(band_energy * 100.0))
+
+        feature_rows.append([np.log1p(rms * 100.0), centroid, bandwidth, zcr, *band_values])
+
+    rows = np.asarray(feature_rows, dtype=np.float32)
+    return np.median(rows, axis=0)
+
+
+def _kmeans(features: np.ndarray, k: int, iterations: int = 30) -> np.ndarray:
+    features = features.astype(np.float32, copy=True)
+    means = features.mean(axis=0)
+    stds = features.std(axis=0)
+    features = (features - means) / np.where(stds < 1e-5, 1.0, stds)
+
+    if k <= 1 or features.shape[0] <= 1:
+        return np.zeros(features.shape[0], dtype=np.int32)
+
+    k = min(k, features.shape[0])
+    centroid_indices = [0]
+    while len(centroid_indices) < k:
+        selected = features[centroid_indices]
+        distances = _pairwise_squared_distances(features, selected)
+        min_distances = np.min(distances, axis=1)
+        for idx in centroid_indices:
+            min_distances[idx] = -1
+        next_idx = int(np.argmax(min_distances))
+        if next_idx in centroid_indices:
+            break
+        centroid_indices.append(next_idx)
+
+    centroids = features[centroid_indices].copy()
+    labels = np.zeros(features.shape[0], dtype=np.int32)
+
+    for _ in range(iterations):
+        dists = _pairwise_squared_distances(features, centroids)
+        new_labels = np.argmin(dists, axis=1).astype(np.int32)
+        if np.array_equal(labels, new_labels):
+            break
+        labels = new_labels
+        for cluster_id in range(centroids.shape[0]):
+            cluster = features[labels == cluster_id]
+            if cluster.size:
+                centroids[cluster_id] = cluster.mean(axis=0)
+
+    return labels
+
+
+def _pairwise_squared_distances(a: np.ndarray, b: np.ndarray) -> np.ndarray:
+    return (
+        np.sum(a * a, axis=1, keepdims=True)
+        - 2 * a @ b.T
+        + np.sum(b * b, axis=1, keepdims=True).T
+    )
+
+
+def _cluster_labels_by_first_appearance(
+    indexed_features: list[tuple[int, np.ndarray]],
+    cluster_ids: np.ndarray,
+    labels: list[str],
+) -> dict[int, str]:
+    ordered_clusters = _ordered_clusters_by_first_appearance(indexed_features, cluster_ids)
+    return {
+        cluster: labels[min(idx, len(labels) - 1)]
+        for idx, cluster in enumerate(ordered_clusters)
+    }
+
+
+def _ordered_clusters_by_first_appearance(
+    indexed_features: list[tuple[int, np.ndarray]],
+    cluster_ids: np.ndarray,
+) -> list[int]:
+    first_seen: dict[int, int] = {}
+    for (idx, _), cluster_id in zip(indexed_features, cluster_ids):
+        first_seen.setdefault(int(cluster_id), idx)
+    return sorted(first_seen, key=first_seen.get)
+
+
+def _normalize_labels(labels: list[str] | tuple[str, ...] | None) -> list[str]:
+    defaults = DEFAULT_SPEAKER_LABELS
+    if not labels:
+        return list(defaults)
+    values = [str(label).strip() for label in labels[:8]]
+    while len(values) < 2:
+        values.append(defaults[len(values)])
+    return [
+        value or (defaults[idx] if idx < len(defaults) else f"Speaker {idx + 1}")
+        for idx, value in enumerate(values)
+    ]
+
+
+def _normalize_voice_profiles(
+    voice_profiles: dict[str, list[float]] | None,
+) -> dict[str, np.ndarray]:
+    if not isinstance(voice_profiles, dict):
+        return {}
+
+    profiles: dict[str, np.ndarray] = {}
+    values = voice_profiles.get(USER_PROFILE_KEY)
+    if isinstance(values, list):
+        try:
+            profile = np.asarray(values, dtype=np.float32)
+        except (TypeError, ValueError):
+            profile = np.asarray([], dtype=np.float32)
+        if profile.ndim == 1 and profile.size:
+            profiles[USER_PROFILE_KEY] = profile
+    return profiles
+
+
+def _map_feature_groups_to_labels(
+    group_features: dict[int, np.ndarray],
+    labels: list[str],
+    voice_profiles: dict[str, np.ndarray],
+    group_order: list[int] | None = None,
+) -> dict[int, str]:
+    if not group_features:
+        return {}
+
+    ordered = group_order or sorted(group_features)
+    groups_by_time = [group for group in ordered if group in group_features]
+    groups_by_time.extend(group for group in group_features if group not in groups_by_time)
+    mapping: dict[int, str] = {}
+    remaining_groups = list(groups_by_time)
+
+    user_profile = voice_profiles.get(USER_PROFILE_KEY)
+    if user_profile is not None:
+        user_group = _confident_profile_group(group_features, user_profile)
+        if user_group is not None:
+            mapping[user_group] = labels[0]
+            remaining_groups = [group for group in remaining_groups if group != user_group]
+        else:
+            logger.info("Voice enrollment ignored for this audio: match was not distinct enough")
+
+    next_label_idx = 1 if mapping else 0
+    for group in remaining_groups:
+        mapping[group] = labels[min(next_label_idx, len(labels) - 1)]
+        next_label_idx += 1
+
+    return mapping
+
+
+def _confident_profile_group(
+    group_features: dict[int, np.ndarray],
+    user_profile: np.ndarray,
+) -> int | None:
+    distances = [
+        (group, _normalized_distance(feature, user_profile))
+        for group, feature in group_features.items()
+    ]
+    distances = [(group, dist) for group, dist in distances if np.isfinite(dist)]
+    if not distances:
+        return None
+
+    distances.sort(key=lambda item: item[1])
+    best_group, best_distance = distances[0]
+
+    if len(distances) == 1:
+        return best_group if best_distance <= _PROFILE_MAX_DISTANCE else None
+
+    second_distance = distances[1][1]
+    margin = second_distance - best_distance
+    ratio = best_distance / max(second_distance, _EPS)
+
+    if (
+        best_distance <= _PROFILE_MAX_DISTANCE
+        and (
+            margin >= _PROFILE_MIN_MARGIN
+            or (
+                best_distance <= _PROFILE_STRONG_DISTANCE
+                and margin >= _PROFILE_STRONG_MARGIN
+                and ratio <= _PROFILE_STRONG_RATIO
+            )
+        )
+    ):
+        return best_group
+
+    logger.debug(
+        "Voice profile match rejected: "
+        f"best={best_distance:.4f}, second={second_distance:.4f}, "
+        f"margin={margin:.4f}, ratio={ratio:.4f}"
+    )
+    return None
+
+
+def _fill_missing_labels(assigned: list[str | None], fallback_label: str) -> list[str]:
+    first_label = next((label for label in assigned if label is not None), fallback_label)
+    previous = first_label
+    filled: list[str] = []
+    for label in assigned:
+        if label is None:
+            filled.append(previous)
+        else:
+            previous = label
+            filled.append(label)
+    return filled
+
+
+def _normalized_distance(a: np.ndarray, b: np.ndarray) -> float:
+    if a.shape != b.shape:
+        return float("inf")
+    a_norm = np.linalg.norm(a)
+    b_norm = np.linalg.norm(b)
+    if a_norm <= _EPS or b_norm <= _EPS:
+        return float("inf")
+    cosine_distance = 1.0 - float(np.dot(a, b) / (a_norm * b_norm))
+    scale = np.maximum(np.maximum(np.abs(a), np.abs(b)), 1.0)
+    scaled_diff = (a - b) / scale
+    return cosine_distance + 0.05 * float(np.mean(scaled_diff * scaled_diff))
+
+
+def _matching_voice_profiles(
+    voice_profiles: dict[str, np.ndarray],
+    feature_size: int,
+) -> dict[str, np.ndarray]:
+    return {
+        key: profile
+        for key, profile in voice_profiles.items()
+        if profile.ndim == 1 and profile.size == feature_size
+    }
+
+
+def _zscore(vectors: np.ndarray) -> np.ndarray:
+    vectors = vectors.astype(np.float32, copy=False)
+    mean = vectors.mean(axis=0)
+    std = vectors.std(axis=0)
+    return (vectors - mean) / np.where(std < 1e-5, 1.0, std)
+
+
+def _rms(samples: np.ndarray) -> float:
+    if samples.size == 0:
+        return 0.0
+    samples = samples.astype(np.float32, copy=False)
+    return float(np.sqrt(np.mean(samples * samples)))

--- a/core/transcription/service.py
+++ b/core/transcription/service.py
@@ -11,6 +11,10 @@ from core.audio.wav_for_whisper import try_load_wav_for_faster_whisper
 from core.temp_file_manager import temp_file_manager
 from core.text.curation import curate_text
 from core.output.writers import SegmentData, TranscriptionResult
+from core.transcription.client_call import (
+    apply_client_call_speakers,
+    format_client_call_transcript,
+)
 from core.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -66,23 +70,35 @@ class _TranscriptionRunnable(QRunnable):
                 return
 
             logger.info(f"Starting transcription: {self.audio_file}")
-
-            whisper_sr = self.model.feature_extractor.sampling_rate
-            audio_input: str | np.ndarray = try_load_wav_for_faster_whisper(
-                self.audio_file, target_sr=whisper_sr
+            logger.info(
+                "Transcription engine: "
+                f"{getattr(self.model, 'engine_name', type(self.model).__name__)}"
             )
-            if audio_input is None:
-                audio_input = str(self.audio_file)
 
+            if getattr(self.model, "expects_file_path", False):
+                audio_input = str(self.audio_file)
+            else:
+                whisper_sr = self.model.feature_extractor.sampling_rate
+                audio_input: str | np.ndarray = try_load_wav_for_faster_whisper(
+                    self.audio_file, target_sr=whisper_sr
+                )
+                if audio_input is None:
+                    audio_input = str(self.audio_file)
+
+            client_call_mode = self.whisper_params.get("client_call_mode", False)
             extra_kwargs = {
-                "without_timestamps": self.whisper_params.get("without_timestamps", True),
+                "without_timestamps": False if client_call_mode else self.whisper_params.get("without_timestamps", True),
                 "word_timestamps": self.whisper_params.get("word_timestamps", False),
                 "beam_size": self.whisper_params.get("beam_size", 5),
                 "vad_filter": self.whisper_params.get("vad_filter", True),
                 "condition_on_previous_text": self.whisper_params.get("condition_on_previous_text", False),
             }
 
-            if self.batch_size is not None and int(self.batch_size) > 1:
+            if (
+                self.batch_size is not None
+                and int(self.batch_size) > 1
+                and not getattr(self.model, "expects_file_path", False)
+            ):
                 # BatchedInferencePipeline requires VAD or clip_timestamps to
                 # split audio into chunks.  Always apply tuned VAD parameters
                 # that maximize audio coverage while avoiding hallucinations
@@ -141,7 +157,22 @@ class _TranscriptionRunnable(QRunnable):
                 else:
                     self.signals.progress_updated.emit(segment_count, -1, -1)
 
-            text = "\n".join(text_parts)
+            if client_call_mode:
+                try:
+                    if apply_client_call_speakers(
+                        self.audio_file,
+                        segment_data_list,
+                        labels=self.whisper_params.get("speaker_labels"),
+                        voice_profiles=self.whisper_params.get("speaker_voice_profiles"),
+                    ):
+                        text = format_client_call_transcript(segment_data_list)
+                    else:
+                        text = "\n".join(text_parts)
+                except Exception as e:
+                    logger.warning(f"Client call speaker labeling failed: {e}")
+                    text = "\n".join(text_parts)
+            else:
+                text = "\n".join(text_parts)
             logger.info(f"Transcription completed successfully ({segment_count} segments)")
 
             result = TranscriptionResult(
@@ -260,7 +291,7 @@ class TranscriptionService(QObject):
 
     def _on_transcription_done(self, text: str) -> None:
         self._is_transcribing = False
-        if self.curate_enabled:
+        if self.curate_enabled and not self._whisper_params.get("client_call_mode", False):
             try:
                 text = curate_text(text)
             except Exception as e:

--- a/gui/clipboard_window.py
+++ b/gui/clipboard_window.py
@@ -14,12 +14,14 @@ class ClipboardSideWindow(QWidget):
     docked_changed = Signal(bool)
     always_on_top_changed = Signal(bool)
     append_mode_changed = Signal(bool)
+    client_call_mode_changed = Signal(bool)
 
     def __init__(self, parent: QWidget | None = None, width: int = 400):
         super().__init__(parent)
 
         self._always_on_top = True
         self._append_mode = False
+        self._client_call_mode = False
         self._docked = True
         self._internal_move = False
         self._internal_move_count = 0
@@ -68,6 +70,14 @@ class ClipboardSideWindow(QWidget):
         self._append_checkbox.toggled.connect(self._on_append_toggled)
         controls.addWidget(self._append_checkbox)
 
+        self._client_call_checkbox = QCheckBox("Speaker Labels")
+        self._client_call_checkbox.setToolTip(
+            "Apply speaker labels to recordings and audio files"
+        )
+        self._client_call_checkbox.setChecked(False)
+        self._client_call_checkbox.toggled.connect(self._on_client_call_toggled)
+        controls.addWidget(self._client_call_checkbox)
+
         self._on_top_checkbox = QCheckBox("Always on Top")
         self._on_top_checkbox.setToolTip("Keep this window above other windows")
         self._on_top_checkbox.setChecked(self._always_on_top)
@@ -83,7 +93,7 @@ class ClipboardSideWindow(QWidget):
 
         layout.addLayout(controls)
 
-        self.setMinimumSize(400, 160)
+        self.setMinimumSize(500, 160)
         self.resize(self._desired_width, self._default_height)
         self.hide()
 
@@ -135,6 +145,20 @@ class ClipboardSideWindow(QWidget):
 
     def is_append_mode(self) -> bool:
         return self._append_mode
+
+    @Slot(bool)
+    def _on_client_call_toggled(self, checked: bool) -> None:
+        self._client_call_mode = checked
+        self.client_call_mode_changed.emit(checked)
+
+    def set_client_call_mode(self, enabled: bool) -> None:
+        self._client_call_mode = enabled
+        self._client_call_checkbox.blockSignals(True)
+        self._client_call_checkbox.setChecked(enabled)
+        self._client_call_checkbox.blockSignals(False)
+
+    def is_client_call_mode(self) -> bool:
+        return self._client_call_mode
 
     def add_transcription(self, text: str) -> None:
         if self._append_mode:

--- a/gui/file_panel.py
+++ b/gui/file_panel.py
@@ -21,7 +21,7 @@ SUPPORTED_AUDIO_EXTENSIONS = [
     ".mkv", ".mp3", ".mp4", ".ogg", ".wav", ".webm", ".wma",
 ]
 
-OUTPUT_FORMATS = ["txt", "srt", "vtt", "json"]
+OUTPUT_FORMATS = ["txt", "srt", "vtt", "tsv", "json"]
 
 OUTPUT_MODES = [
     ("Clipboard only", "clipboard"),

--- a/gui/main_window.py
+++ b/gui/main_window.py
@@ -54,6 +54,7 @@ SETTINGS_CLIPBOARD_DOCKED = "clipboard/docked"
 SETTINGS_CLIPBOARD_VISIBLE = "clipboard/visible"
 SETTINGS_CLIPBOARD_ALWAYS_ON_TOP = "clipboard/always_on_top"
 SETTINGS_APPEND_MODE = "clipboard/append_mode"
+SETTINGS_CLIENT_CALL_MODE = "clipboard/client_call_mode"
 SETTINGS_MODEL = "model/name"
 SETTINGS_DEVICE = "model/device"
 SETTINGS_QUANTIZATION = "model/quantization"
@@ -159,6 +160,7 @@ class MainWindow(QMainWindow):
         "quantization": "float32",
         "task_mode": "transcribe",
         "append_mode": False,
+        "client_call_mode": False,
         "clipboard_visible": False,
         "clipboard_always_on_top": True,
         "clipboard_docked": True,
@@ -197,6 +199,9 @@ class MainWindow(QMainWindow):
         )
         self.clipboard_window.always_on_top_changed.connect(
             self._on_clipboard_always_on_top_changed
+        )
+        self.clipboard_window.client_call_mode_changed.connect(
+            self._on_client_call_mode_changed
         )
 
         self.file_panel = FilePanelWindow(None, width=340)
@@ -350,6 +355,15 @@ class MainWindow(QMainWindow):
         )
         self.clipboard_window.set_append_mode(append_mode)
 
+        client_call_mode = self.settings.value(
+            SETTINGS_CLIENT_CALL_MODE,
+            config_manager.get_value(
+                "client_call_mode", self.DEFAULTS["client_call_mode"]
+            ),
+            type=bool,
+        )
+        self.clipboard_window.set_client_call_mode(client_call_mode)
+
         always_on_top = self.settings.value(
             SETTINGS_CLIPBOARD_ALWAYS_ON_TOP,
             self.DEFAULTS["clipboard_always_on_top"],
@@ -419,7 +433,9 @@ class MainWindow(QMainWindow):
             config_manager.set_model_settings(model, quantization, device)
             config_manager.set_value("task_mode", task_mode)
             config_manager.set_value("clipboard_append_mode", append_mode)
+            config_manager.set_value("client_call_mode", client_call_mode)
             config_manager.set_value("show_clipboard_window", self._clipboard_visible)
+            self.controller.set_whisper_params(self._current_whisper_params())
         except Exception as e:
             logger.warning(f"Failed to sync config manager: {e}")
 
@@ -454,6 +470,9 @@ class MainWindow(QMainWindow):
 
         self.settings.setValue(
             SETTINGS_APPEND_MODE, self.clipboard_window.is_append_mode()
+        )
+        self.settings.setValue(
+            SETTINGS_CLIENT_CALL_MODE, self.clipboard_window.is_client_call_mode()
         )
         self.settings.setValue(SETTINGS_CLIPBOARD_VISIBLE, self._clipboard_visible)
         self.settings.setValue(
@@ -695,6 +714,28 @@ class MainWindow(QMainWindow):
     def _update_model_status(self, text: str) -> None:
         self.model_status_label.setText(text)
 
+    def _current_whisper_params(self) -> dict:
+        include_timestamps = config_manager.get_value(
+            "include_timestamps",
+            not config_manager.get_value("without_timestamps", True),
+        )
+        return {
+            "without_timestamps": not include_timestamps,
+            "word_timestamps": config_manager.get_value("word_timestamps", False),
+            "beam_size": config_manager.get_value("beam_size", 5),
+            "vad_filter": config_manager.get_value("vad_filter", False),
+            "condition_on_previous_text": config_manager.get_value(
+                "condition_on_previous_text", True
+            ),
+            "client_call_mode": self.clipboard_window.is_client_call_mode(),
+            "speaker_labels": config_manager.get_value(
+                "speaker_labels", ["Lawyer", "Client"]
+            ),
+            "speaker_voice_profiles": config_manager.get_value(
+                "speaker_voice_profiles", {}
+            ),
+        }
+
     def _show_current_model_status(self) -> None:
         if self._model_is_loaded:
             name = self.loaded_model_settings.get("model_name", "")
@@ -704,7 +745,12 @@ class MainWindow(QMainWindow):
                 f"  |  server: on ({self._server_port})"
                 if self._server_mode_enabled else ""
             )
-            self._update_model_status(f"{name} ({quant} / {device}){server_bit}")
+            if quant == "onnx":
+                self._update_model_status(
+                    f"{name} (ONNX / {device.upper()}){server_bit}"
+                )
+            else:
+                self._update_model_status(f"{name} ({quant} / {device}){server_bit}")
         else:
             self._update_model_status("No model loaded")
 
@@ -802,6 +848,10 @@ class MainWindow(QMainWindow):
             "vad_filter": config_manager.get_value("vad_filter", False),
             "condition_on_previous_text": config_manager.get_value("condition_on_previous_text", True),
         }
+        speaker_labels = config_manager.get_value(
+            "speaker_labels", ["Lawyer", "Client"]
+        )
+        speaker_profiles = config_manager.get_value("speaker_voice_profiles", {})
         server_settings = {
             "server_mode_enabled": self._server_mode_enabled,
             "server_port": self._server_port,
@@ -814,6 +864,8 @@ class MainWindow(QMainWindow):
             current_task_mode=self.task_mode,
             current_audio_device=current_audio,
             current_whisper_settings=whisper_settings,
+            current_speaker_labels=speaker_labels,
+            current_speaker_profiles=speaker_profiles,
             current_ext_checked=self.file_panel.get_ext_checked(),
             current_server_settings=server_settings,
             is_busy_check=self._is_busy,
@@ -822,6 +874,7 @@ class MainWindow(QMainWindow):
         dlg.audio_device_changed.connect(self._on_audio_device_changed)
         dlg.task_mode_changed.connect(self._on_task_mode_changed)
         dlg.whisper_settings_changed.connect(self._on_whisper_settings_changed)
+        dlg.speaker_settings_changed.connect(self._on_speaker_settings_changed)
         dlg.file_types_changed.connect(self._on_file_types_changed)
         dlg.server_mode_changed.connect(self._on_server_mode_changed)
         dlg.exec()
@@ -885,6 +938,12 @@ class MainWindow(QMainWindow):
     def _on_append_mode_changed(self, checked: bool) -> None:
         self._save_config("clipboard_append_mode", checked)
 
+    @Slot(bool)
+    def _on_client_call_mode_changed(self, checked: bool) -> None:
+        self.settings.setValue(SETTINGS_CLIENT_CALL_MODE, checked)
+        self._save_config("client_call_mode", checked)
+        self.controller.set_whisper_params(self._current_whisper_params())
+
     @Slot(str, str)
     def _show_error_dialog(self, title: str, message: str) -> None:
         logger.error(f"Error: {title} - {message}")
@@ -908,15 +967,13 @@ class MainWindow(QMainWindow):
     def _on_whisper_settings_changed(self, settings: dict) -> None:
         for key, value in settings.items():
             self._save_config(key, value)
-        # Translate include_timestamps to the params the transcription service expects
-        whisper_params = {
-            "without_timestamps": not settings.get("include_timestamps", False),
-            "word_timestamps": False,
-            "beam_size": settings.get("beam_size", 5),
-            "vad_filter": settings.get("vad_filter", False),
-            "condition_on_previous_text": settings.get("condition_on_previous_text", True),
-        }
-        self.controller.set_whisper_params(whisper_params)
+        self.controller.set_whisper_params(self._current_whisper_params())
+
+    def _on_speaker_settings_changed(self, settings: dict) -> None:
+        for key in ("speaker_labels", "speaker_voice_profiles"):
+            if key in settings:
+                self._save_config(key, settings[key])
+        self.controller.set_whisper_params(self._current_whisper_params())
 
     def _on_file_types_changed(self, ext_checked: dict) -> None:
         self.file_panel.set_ext_checked(ext_checked)
@@ -1058,7 +1115,7 @@ class MainWindow(QMainWindow):
         self._pending_source_file = file_path
 
         # Force timestamps on for formats that require them
-        if output_format in ("srt", "vtt"):
+        if output_format in ("srt", "vtt", "tsv"):
             self.controller.transcription_service.set_timestamps_override(False)
         else:
             self.controller.transcription_service.set_timestamps_override(None)
@@ -1109,17 +1166,9 @@ class MainWindow(QMainWindow):
 
     @Slot(list, str, str, int, str)
     def _on_batch_start(self, files, fmt, output_dir, batch_size, task_mode) -> None:
-        include_timestamps = config_manager.get_value("include_timestamps", False)
-        # Force timestamps on for formats that require them
-        if fmt in ("srt", "vtt"):
-            include_timestamps = True
-        whisper_params = {
-            "without_timestamps": not include_timestamps,
-            "word_timestamps": False,
-            "beam_size": config_manager.get_value("beam_size", 5),
-            "vad_filter": config_manager.get_value("vad_filter", False),
-            "condition_on_previous_text": config_manager.get_value("condition_on_previous_text", True),
-        }
+        whisper_params = self._current_whisper_params()
+        if fmt in ("srt", "vtt", "tsv"):
+            whisper_params["without_timestamps"] = False
         self.record_button.setText("Transcribing...")
         self.record_button.set_state(WaveformButton.TRANSCRIBING)
         self.record_button.setEnabled(False)

--- a/gui/settings_dialog.py
+++ b/gui/settings_dialog.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from PySide6.QtCore import QUrl, Signal
+from PySide6.QtCore import Qt, QUrl, Signal
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
     QDialog,
@@ -16,6 +16,10 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QLabel,
     QSpinBox,
+    QLineEdit,
+    QMessageBox,
+    QApplication,
+    QDialogButtonBox,
 )
 
 from core.models.metadata import ModelMetadata
@@ -27,11 +31,189 @@ from core.logging_config import get_logger
 logger = get_logger(__name__)
 
 
+class SpeakerLabelsDialog(QDialog):
+    def __init__(self, parent: QWidget | None, labels: list[str]):
+        super().__init__(parent)
+        self.setWindowTitle("Speaker Labels")
+        self.setModal(True)
+        self.setMinimumWidth(400)
+        self._defaults = ["Lawyer", "Client"]
+        self._labels = list(labels or self._defaults)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(12)
+
+        self._count_spin = QSpinBox()
+        self._count_spin.setRange(2, 8)
+        self._count_spin.setValue(max(2, min(8, len(self._labels))))
+        self._count_spin.valueChanged.connect(self._refresh_visible_rows)
+
+        form = QFormLayout()
+        form.addRow("Expected Speakers", self._count_spin)
+        self._rows: list[tuple[QLabel, QLineEdit]] = []
+        for idx in range(8):
+            default = self._default_label(idx)
+            value = self._labels[idx] if idx < len(self._labels) else default
+            label = QLabel(f"Speaker {idx + 1}")
+            edit = QLineEdit(value)
+            form.addRow(label, edit)
+            self._rows.append((label, edit))
+        layout.addLayout(form)
+        self._refresh_visible_rows()
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def get_labels(self) -> list[str]:
+        labels = []
+        for idx, (_, edit) in enumerate(self._rows[: self._count_spin.value()]):
+            labels.append(edit.text().strip() or self._default_label(idx))
+        return labels
+
+    def _refresh_visible_rows(self) -> None:
+        count = self._count_spin.value()
+        for idx, (label, edit) in enumerate(self._rows):
+            visible = idx < count
+            label.setVisible(visible)
+            edit.setVisible(visible)
+
+    def _default_label(self, idx: int) -> str:
+        if idx < len(self._defaults):
+            return self._defaults[idx]
+        return f"Speaker {idx + 1}"
+
+
+class VoiceEnrollmentDialog(QDialog):
+    _PROFILE_KEY = "speaker_1"
+
+    def __init__(
+        self,
+        parent: QWidget | None,
+        labels: list[str],
+        profiles: dict,
+        device_provider,
+    ):
+        super().__init__(parent)
+        self.setWindowTitle("Voice Enrollment")
+        self.setModal(True)
+        self.setMinimumWidth(460)
+
+        self._labels = labels
+        self._profiles = {
+            key: list(value)
+            for key, value in (profiles or {}).items()
+            if key == self._PROFILE_KEY and isinstance(value, list)
+        }
+        self._device_provider = device_provider
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(16, 16, 16, 16)
+        layout.setSpacing(12)
+
+        hint = QLabel(
+            "Record 5-6 seconds of your voice. The app uses this only when it is a confident match."
+        )
+        hint.setWordWrap(True)
+        layout.addWidget(hint)
+
+        row = QHBoxLayout()
+        record_btn = QPushButton("Record")
+        record_btn.clicked.connect(self._record_profile)
+        row.addWidget(record_btn)
+
+        clear_btn = QPushButton("Clear")
+        clear_btn.clicked.connect(self._clear_profile)
+        row.addWidget(clear_btn)
+
+        self._status_label = QLabel()
+        row.addWidget(self._status_label, 1)
+        layout.addLayout(row)
+
+        self._refresh_status()
+
+        buttons = QDialogButtonBox(QDialogButtonBox.Ok)
+        buttons.accepted.connect(self.accept)
+        layout.addWidget(buttons)
+
+    def get_profiles(self) -> dict:
+        return dict(self._profiles)
+
+    def _refresh_status(self) -> None:
+        self._status_label.setText(
+            "Enrolled" if self._PROFILE_KEY in self._profiles else "No sample"
+        )
+
+    def _clear_profile(self) -> None:
+        self._profiles.pop(self._PROFILE_KEY, None)
+        self._refresh_status()
+
+    def _record_profile(self) -> None:
+        QMessageBox.information(
+            self,
+            "Voice Enrollment",
+            "After you click OK, speak naturally for about 6 seconds.",
+        )
+
+        try:
+            import numpy as np
+            import sounddevice as sd
+            from core.transcription.client_call import build_voice_profile_from_samples
+
+            device_id = self._device_provider()
+            sample_rate = self._choose_sample_rate(sd, device_id)
+            frames = int(sample_rate * 6)
+
+            QApplication.setOverrideCursor(Qt.WaitCursor)
+            cursor_set = True
+            QApplication.processEvents()
+            recording = sd.rec(
+                frames,
+                samplerate=sample_rate,
+                channels=1,
+                dtype="float32",
+                device=device_id,
+            )
+            sd.wait()
+            samples = np.asarray(recording).reshape(-1)
+            self._profiles[self._PROFILE_KEY] = build_voice_profile_from_samples(
+                samples, sample_rate
+            )
+            self._refresh_status()
+            QMessageBox.information(self, "Voice Enrollment", "Saved your voice sample.")
+        except Exception as e:
+            logger.exception("Voice enrollment failed")
+            QMessageBox.warning(
+                self, "Voice Enrollment", f"Could not save voice sample:\n{e}"
+            )
+        finally:
+            if "cursor_set" in locals():
+                QApplication.restoreOverrideCursor()
+
+    @staticmethod
+    def _choose_sample_rate(sd, device_id: int | None) -> int:
+        for sample_rate in (16000, 44100, 48000):
+            try:
+                sd.check_input_settings(
+                    device=device_id,
+                    samplerate=sample_rate,
+                    channels=1,
+                    dtype="float32",
+                )
+                return sample_rate
+            except Exception:
+                continue
+        return 44100
+
+
 class SettingsDialog(QDialog):
     model_update_requested = Signal(str, str, str)
     audio_device_changed = Signal(str, str)
     task_mode_changed = Signal(str)
     whisper_settings_changed = Signal(object)
+    speaker_settings_changed = Signal(object)
     server_mode_changed = Signal(bool, int)
 
     file_types_changed = Signal(object)
@@ -45,6 +227,8 @@ class SettingsDialog(QDialog):
         current_task_mode: str = "transcribe",
         current_audio_device: dict[str, str] | None = None,
         current_whisper_settings: dict | None = None,
+        current_speaker_labels: list[str] | None = None,
+        current_speaker_profiles: dict | None = None,
         current_ext_checked: dict[str, bool] | None = None,
         current_server_settings: dict | None = None,
         is_busy_check=None,
@@ -67,6 +251,14 @@ class SettingsDialog(QDialog):
             "vad_filter": True,
             "condition_on_previous_text": False,
         }
+        self.current_speaker_labels = list(
+            current_speaker_labels or ["Lawyer", "Client"]
+        )
+        while len(self.current_speaker_labels) < 2:
+            self.current_speaker_labels.append(
+                ["Lawyer", "Client"][len(self.current_speaker_labels)]
+            )
+        self.current_speaker_profiles = dict(current_speaker_profiles or {})
         self.current_server_settings = current_server_settings or {
             "server_mode_enabled": False,
             "server_port": 8765,
@@ -94,7 +286,7 @@ class SettingsDialog(QDialog):
         left_column = QVBoxLayout()
         left_column.setSpacing(12)
 
-        model_group = QGroupBox("Whisper Model")
+        model_group = QGroupBox("Speech Model")
         model_form = QFormLayout(model_group)
         model_form.setHorizontalSpacing(12)
         model_form.setVerticalSpacing(10)
@@ -174,6 +366,24 @@ class SettingsDialog(QDialog):
         whisper_form.addRow("Condition on Previous", self.condition_on_previous_cb)
 
         right_column.addWidget(whisper_group)
+
+        speaker_group = QGroupBox("Speaker Labels")
+        speaker_layout = QHBoxLayout(speaker_group)
+        speaker_layout.setSpacing(8)
+
+        self._speaker_labels_btn = QPushButton("Speaker Labels...")
+        self._speaker_labels_btn.setFixedHeight(28)
+        self._speaker_labels_btn.clicked.connect(self._open_speaker_labels_dialog)
+        speaker_layout.addWidget(self._speaker_labels_btn)
+
+        self._voice_enrollment_btn = QPushButton("Voice Enrollment...")
+        self._voice_enrollment_btn.setFixedHeight(28)
+        self._voice_enrollment_btn.clicked.connect(
+            self._open_voice_enrollment_dialog
+        )
+        speaker_layout.addWidget(self._voice_enrollment_btn)
+
+        right_column.addWidget(speaker_group)
 
         server_group = QGroupBox("Server Mode")
         server_vbox = QVBoxLayout(server_group)
@@ -414,6 +624,8 @@ class SettingsDialog(QDialog):
             self.beam_size_spin,
             self.vad_filter_cb,
             self.condition_on_previous_cb,
+            self._speaker_labels_btn,
+            self._voice_enrollment_btn,
         ]
         for w in locked_widgets:
             w.setEnabled(not server_on)
@@ -434,6 +646,35 @@ class SettingsDialog(QDialog):
         else:
             self.update_btn.setText("Update Settings")
         update_button_property(self.update_btn, "changed", has_changes)
+
+    def _open_speaker_labels_dialog(self) -> None:
+        dlg = SpeakerLabelsDialog(self, self.current_speaker_labels)
+        if dlg.exec() == QDialog.Accepted:
+            self.current_speaker_labels = dlg.get_labels()
+            self.speaker_settings_changed.emit({
+                "speaker_labels": self.current_speaker_labels,
+                "speaker_voice_profiles": self.current_speaker_profiles,
+            })
+
+    def _open_voice_enrollment_dialog(self) -> None:
+        dlg = VoiceEnrollmentDialog(
+            self,
+            self.current_speaker_labels,
+            self.current_speaker_profiles,
+            self._selected_audio_device_id,
+        )
+        if dlg.exec() == QDialog.Accepted:
+            self.current_speaker_profiles = dlg.get_profiles()
+            self.speaker_settings_changed.emit({
+                "speaker_labels": self.current_speaker_labels,
+                "speaker_voice_profiles": self.current_speaker_profiles,
+            })
+
+    def _selected_audio_device_id(self) -> int | None:
+        data = self.audio_device_dropdown.currentData()
+        if isinstance(data, dict):
+            return data.get("id")
+        return None
 
     def _open_file_types_dialog(self) -> None:
         dlg = FileTypesDialog(self, self._ext_checked)

--- a/install.py
+++ b/install.py
@@ -3,12 +3,24 @@ import subprocess
 import time
 import os
 import tkinter as tk
+from pathlib import Path
 from tkinter import messagebox
 
 _gpu_packages = [
     "nvidia-cuda-runtime-cu12==12.8.90",
     "nvidia-cublas-cu12==12.8.4.1",
+    "nvidia-cudnn-cu12==9.10.2.21",
     "nvidia-ml-py",
+]
+
+_parakeet_onnx_gpu_packages = [
+    "onnx-asr[hub]",
+    "onnxruntime-gpu!=1.24.1",
+]
+
+_parakeet_onnx_cpu_packages = [
+    "onnx-asr[hub]",
+    "onnxruntime!=1.24.1",
 ]
 
 _supported_python_versions = {"cp311", "cp312", "cp313"}
@@ -26,6 +38,7 @@ libs = [
 
 
 start_time = time.time()
+APP_DIR = Path(__file__).resolve().parent
 
 def enable_ansi_colors():
     if sys.platform == "win32":
@@ -36,6 +49,17 @@ def enable_ansi_colors():
         kernel32.GetConsoleMode(stdout_handle, ctypes.byref(mode))
         mode.value |= 0x0004
         kernel32.SetConsoleMode(stdout_handle, mode)
+
+def configure_install_caches():
+    cache_dirs = {
+        "UV_CACHE_DIR": APP_DIR / "uv-cache",
+        "PIP_CACHE_DIR": APP_DIR / "pip-cache",
+        "TMP": APP_DIR / "pip-tmp",
+        "TEMP": APP_DIR / "pip-tmp",
+    }
+    for env_name, path in cache_dirs.items():
+        path.mkdir(parents=True, exist_ok=True)
+        os.environ.setdefault(env_name, str(path))
 
 def has_nvidia_gpu():
     try:
@@ -105,6 +129,13 @@ def build_library_list():
 
     return all_libs
 
+def build_parakeet_onnx_library_list():
+    return (
+        list(_parakeet_onnx_gpu_packages)
+        if hardware_type == "GPU"
+        else list(_parakeet_onnx_cpu_packages)
+    )
+
 def install_libraries(libraries, max_retries=5, delay=3):
     command = ["uv", "pip", "install"] + libraries
 
@@ -126,6 +157,7 @@ def install_libraries(libraries, max_retries=5, delay=3):
 
 def main():
     enable_ansi_colors()
+    configure_install_caches()
 
     if not check_python_version_and_confirm():
         sys.exit(1)
@@ -147,6 +179,19 @@ def main():
     print(f"\033[92mInstalling {len(all_libs)} libraries ({hardware_type} configuration):\033[0m")
     success, attempts = install_libraries(all_libs)
 
+    parakeet_success = None
+    parakeet_attempts = 0
+    if tkinter_message_box(
+        "Optional Parakeet ONNX",
+        "Install experimental Parakeet ONNX support?\n\n"
+        "This avoids NVIDIA NeMo and uses ONNX Runtime locally. "
+        "The Parakeet model itself downloads the first time you select it.",
+        yes_no=True,
+    ):
+        parakeet_libs = build_parakeet_onnx_library_list()
+        print(f"\033[92mInstalling Parakeet ONNX support ({hardware_type} configuration):\033[0m")
+        parakeet_success, parakeet_attempts = install_libraries(parakeet_libs)
+
     print("\n----- Installation Summary -----")
     if not success:
         print(f"\033[91mInstallation failed after {attempts} attempts.\033[0m")
@@ -154,6 +199,15 @@ def main():
         print(f"\033[93mAll libraries installed successfully after {attempts} attempts.\033[0m")
     else:
         print("\033[92mAll libraries installed successfully on the first attempt.\033[0m")
+
+    if parakeet_success is not None:
+        if parakeet_success:
+            print("\033[92mParakeet ONNX support installed successfully.\033[0m")
+        else:
+            print(
+                f"\033[93mParakeet ONNX support failed after {parakeet_attempts} "
+                "attempt(s). Faster Whisper remains unaffected.\033[0m"
+            )
 
     end_time = time.time()
     total_time = end_time - start_time


### PR DESCRIPTION
## Summary

This PR adds optional local speaker labeling/diarization support and experimental NVIDIA Parakeet ONNX transcription support.

## Changes

- Added a `Speaker Labels` checkbox in the clipboard panel for recorded calls and imported audio files.
- Added Settings popups for:
  - Editing expected speaker labels, supporting 2-8 speakers.
  - Optional voice enrollment for the primary speaker.
- Applied speaker labeling to both live recordings and file/batch transcription output.
- Added speaker-aware output for txt, srt, vtt, tsv, and json formats.
- Added optional local Parakeet model support via `parakeet-tdt-0.6b-v3-onnx`.
- Uses ONNX Runtime / `onnx-asr` for Parakeet instead of NVIDIA NeMo.
- Adds installer prompt for optional Parakeet ONNX dependencies.
- Adds clearer model status for ONNX/Parakeet use.
- Updates README documentation.
- Ignores local runtime/model/cache directories.

## Notes

Parakeet support is transcription-only and optional. Faster Whisper remains the default and fallback path.

Speaker labeling is a lightweight local diarization helper. It does not send audio to any cloud service and supports more than two expected speakers for imported/batch files.

## Validation

- Ran Python compile check across `config`, `core`, `gui`, `install.py`, and `main.py`.
- Ran Git whitespace check with `git diff --check`.
